### PR TITLE
Add supporting for semi-supervised datasets to register_dataset

### DIFF
--- a/coala/coordinator.py
+++ b/coala/coordinator.py
@@ -351,6 +351,7 @@ def _set_random_seed(seed):
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
 
 
 # Initialize the global coordinator object
@@ -486,19 +487,24 @@ def get_coordinator():
     return _global_coord
 
 
-def register_dataset(train_data, test_data, val_data=None, s_train_data=None, u_train_data=None):
+def register_dataset(train_data, test_data, val_data=None):
     """Register datasets for federated learning training.
 
     Args:
-        train_data (:obj:`FederatedDataset`): Training dataset.
+        train_data (:obj:`FederatedDataset` or dict[obj:`FederatedDataset`]): Training dataset.
         test_data (:obj:`FederatedDataset`): Testing dataset.
         val_data (:obj:`FederatedDataset`): Validation dataset.
-        s_train_data (:obj:`FederatedDataset`): Supervised training dataset (semi-supervised setting only).
-        u_train_data (:obj:`FederatedDataset`): Unsupervised training dataset (semi-supervised setting only).
+        train_data.s_train_data (:obj:`FederatedDataset`): Supervised training dataset (semi-supervised setting only).
+        train_data.u_train_data (:obj:`FederatedDataset`): Unsupervised training dataset (semi-supervised setting only).
     """
     global _global_coord
-    _global_coord.register_dataset(train_data, test_data, val_data, s_train_data, u_train_data)
+    if type(train_data) == dict:
+        s_train_data = train_data['s_train_data']
+        u_train_data = train_data['u_train_data']
 
+        _global_coord.register_dataset(u_train_data, test_data, val_data, s_train_data, u_train_data)
+    else:
+        _global_coord.register_dataset(train_data, test_data, val_data)
 
 def register_model(model):
     """Register model for federated learning training.

--- a/coala/coordinator.py
+++ b/coala/coordinator.py
@@ -278,7 +278,7 @@ class Coordinator(object):
 
         client.start_service()
 
-    def register_dataset(self, train_data, test_data, val_data=None):
+    def register_dataset(self, train_data, test_data, val_data=None, s_train_data=None, u_train_data=None):
         """Register datasets.
 
         Datasets should inherit from :obj:`FederatedDataset`, e.g., :obj:`FederatedTensorDataset`.
@@ -287,11 +287,15 @@ class Coordinator(object):
             train_data (:obj:`FederatedDataset`): Training dataset.
             test_data (:obj:`FederatedDataset`): Testing dataset.
             val_data (:obj:`FederatedDataset`): Validation dataset.
+            s_train_data (:obj:`FederatedDataset`): Supervised training dataset (semi-supervised setting only).
+            u_train_data (:obj:`FederatedDataset`): Unsupervised training dataset (semi-supervised setting only).
         """
         self.registered_dataset = True
         self.train_data = train_data
         self.test_data = test_data
         self.val_data = val_data
+        self.s_train_data = s_train_data
+        self.u_train_data = u_train_data
 
     def register_model(self, model):
         """Register customized model for federated learning.
@@ -482,16 +486,18 @@ def get_coordinator():
     return _global_coord
 
 
-def register_dataset(train_data, test_data, val_data=None):
+def register_dataset(train_data, test_data, val_data=None, s_train_data=None, u_train_data=None):
     """Register datasets for federated learning training.
 
     Args:
         train_data (:obj:`FederatedDataset`): Training dataset.
         test_data (:obj:`FederatedDataset`): Testing dataset.
         val_data (:obj:`FederatedDataset`): Validation dataset.
+        s_train_data (:obj:`FederatedDataset`): Supervised training dataset (semi-supervised setting only).
+        u_train_data (:obj:`FederatedDataset`): Unsupervised training dataset (semi-supervised setting only).
     """
     global _global_coord
-    _global_coord.register_dataset(train_data, test_data, val_data)
+    _global_coord.register_dataset(train_data, test_data, val_data, s_train_data, u_train_data)
 
 
 def register_model(model):


### PR DESCRIPTION
In previous code, `s_train_data` and 'u_train_data' can only be set from internal data split instead of using `register_dataset` as `train_data`, `test_data` and `val_data`.

Two optional arguments, `u_train_data` and `s_train_data`, are now added to `register_dataset`, which fixes this issue without changing behaviors for supervised settings.